### PR TITLE
example: Demonstrate stateful widgets and data passing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -86,71 +86,74 @@ class FirstPage extends StatelessWidget {
 class SecondPage extends StatelessWidget {
   final TextEditingController _textFieldController = TextEditingController();
   final String title;
- SecondPage({Key? key, required this.title}) : super(key: key);
-  
+  SecondPage({Key? key, required this.title}) : super(key: key);
+
   _displayDialog(BuildContext context) async {
     return showDialog(
         context: context,
         builder: (context) {
           return AlertDialog(
-            title: const Text('Enter Grade'),
-            content: TextField(
-              controller: _textFieldController,
-              textInputAction: TextInputAction.go,
-              keyboardType: const TextInputType.numberWithOptions(),
-              //decoration: const InputDecoration(hintText: "Enter your number"),
-            ),
-            actions: <Widget>[
-              TextButton(
-                onPressed: () {
-                 _navigateAndDisplaySelection(context);},
-                 //Navigator.pop(context);},
-                child: const Text('Submit')), 
-                
-              ]
-          );
+              title: const Text('Enter Grade'),
+              content: TextField(
+                controller: _textFieldController,
+                textInputAction: TextInputAction.go,
+                keyboardType: const TextInputType.numberWithOptions(),
+                //decoration: const InputDecoration(hintText: "Enter your number"),
+              ),
+              actions: <Widget>[
+                TextButton(
+                    onPressed: () {
+                      _navigateAndDisplaySelection(context);
+                    },
+                    //Navigator.pop(context);},
+                    child: const Text('Submit')),
+              ]);
         });
   }
- Future<void> _navigateAndDisplaySelection(BuildContext context) async {
+
+  Future<void> _navigateAndDisplaySelection(BuildContext context) async {
     // Navigator.push returns a Future that completes after calling
     // Navigator.pop on the Selection Screen.
     final result = await Navigator.push(
       context,
-      MaterialPageRoute(builder: (context) => SecondPage(title: 'Exam 1',)),
+      MaterialPageRoute(
+          builder: (context) => SecondPage(
+                title: 'Exam 1',
+              )),
     );
-  // When a BuildContext is used from a StatefulWidget, the mounted property
-  // must be checked after an asynchronous gap.
-  //if (!mounted) return;
-  // After the Selection Screen returns a result, hide any previous snackbars
-  // and show the new result.
-  ScaffoldMessenger.of(context)
-    ..removeCurrentSnackBar()
-    ..showSnackBar(SnackBar(content: Text('$result')));
-}
+    // When a BuildContext is used from a StatefulWidget, the mounted property
+    // must be checked after an asynchronous gap.
+    //if (!mounted) return;
+    // After the Selection Screen returns a result, hide any previous snackbars
+    // and show the new result.
+    ScaffoldMessenger.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text('$result')));
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: Text(title),
-        ),
-        body: Column(
-            children: <Widget>[
-              TextButton(                
-                onPressed: () { 
-                 _displayDialog(context);},                  
-                child: const Text('Dream Grade'),     
-              ),
-              TextButton(
-                onPressed: () => {_displayDialog(context)},
-                child: const Text('Real Grade'),
-              ),
-              //Text( _textFieldController.text)
-            ],
+      appBar: AppBar(
+        title: Text(title),
+      ),
+      body: Column(
+        children: <Widget>[
+          TextButton(
+            onPressed: () {
+              _displayDialog(context);
+            },
+            child: const Text('Dream Grade'),
           ),
-        );
+          TextButton(
+            onPressed: () => {_displayDialog(context)},
+            child: const Text('Real Grade'),
+          ),
+          //Text( _textFieldController.text)
+        ],
+      ),
+    );
   }
- 
 }
 
 class ThirdPage extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,7 +41,7 @@ class FirstPage extends StatelessWidget {
             TextButton(
               onPressed: () {
                 Navigator.push(context, MaterialPageRoute(builder: (context) {
-                  return SecondPage(title: 'Exam 1');
+                  return const _SecondPage(title: 'Exam 1');
                 }));
               },
               child: const Text('Exam 1'),
@@ -83,75 +83,79 @@ class FirstPage extends StatelessWidget {
   }
 }
 
-class SecondPage extends StatelessWidget {
-  final TextEditingController _textFieldController = TextEditingController();
+class _SecondPage extends StatefulWidget {
   final String title;
-  SecondPage({Key? key, required this.title}) : super(key: key);
+  const _SecondPage({Key? key, required this.title}) : super(key: key);
 
-  _displayDialog(BuildContext context) async {
-    return showDialog(
-        context: context,
-        builder: (context) {
-          return AlertDialog(
-              title: const Text('Enter Grade'),
-              content: TextField(
-                controller: _textFieldController,
-                textInputAction: TextInputAction.go,
-                keyboardType: const TextInputType.numberWithOptions(),
-                //decoration: const InputDecoration(hintText: "Enter your number"),
-              ),
-              actions: <Widget>[
-                TextButton(
-                    onPressed: () {
-                      _navigateAndDisplaySelection(context);
-                    },
-                    //Navigator.pop(context);},
-                    child: const Text('Submit')),
-              ]);
-        });
-  }
+  @override
+  State<StatefulWidget> createState() => SecondPageState();
+}
 
-  Future<void> _navigateAndDisplaySelection(BuildContext context) async {
-    // Navigator.push returns a Future that completes after calling
-    // Navigator.pop on the Selection Screen.
-    final result = await Navigator.push(
-      context,
-      MaterialPageRoute(
-          builder: (context) => SecondPage(
-                title: 'Exam 1',
-              )),
-    );
-    // When a BuildContext is used from a StatefulWidget, the mounted property
-    // must be checked after an asynchronous gap.
-    //if (!mounted) return;
-    // After the Selection Screen returns a result, hide any previous snackbars
-    // and show the new result.
-    ScaffoldMessenger.of(context)
-      ..removeCurrentSnackBar()
-      ..showSnackBar(SnackBar(content: Text('$result')));
-  }
+class SecondPageState extends State<_SecondPage> {
+  double? dreamGrade;
+  double? actualGrade;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(title),
+        title: Text(widget.title),
       ),
       body: Column(
         children: <Widget>[
           TextButton(
-            onPressed: () {
-              _displayDialog(context);
+            onPressed: () async {
+              final result = await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => GradeWidget()),
+              );
+
+              setState(() => dreamGrade = double.parse(result));
             },
             child: const Text('Dream Grade'),
           ),
           TextButton(
-            onPressed: () => {_displayDialog(context)},
+            onPressed: () async {
+              final result = await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => GradeWidget()),
+              );
+
+              setState(() => actualGrade = double.parse(result));
+            },
             child: const Text('Real Grade'),
           ),
-          //Text( _textFieldController.text)
+          Text("Dream Grade: $dreamGrade"),
+          Text("Actual Grade: $actualGrade")
         ],
       ),
+    );
+  }
+}
+
+class GradeWidget extends StatelessWidget {
+  final TextEditingController _textFieldController = TextEditingController();
+
+  GradeWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Enter Grade'),
+      content: TextField(
+        controller: _textFieldController,
+        textInputAction: TextInputAction.go,
+        keyboardType: const TextInputType.numberWithOptions(),
+        //decoration: const InputDecoration(hintText: "Enter your number"),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Submit'),
+          onPressed: () {
+            Navigator.of(context).pop(_textFieldController.text);
+          },
+        )
+      ],
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,28 +80,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -141,21 +134,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR demonstrates how data passing via `Navigator` can be used in combination with stateful widgets to display user-selected values in a Widget.

It only demonstrates this change for the "Exam 1", and does not address anything else.